### PR TITLE
Adds try/except around http_action assignment

### DIFF
--- a/curl_to_requests/curl_to_requests.py
+++ b/curl_to_requests/curl_to_requests.py
@@ -130,7 +130,10 @@ def curl_to_requests(curl_str):
         raise ValueError("Could not parse arguments.")
 
     url = args.target_url
-    http_action = args.request.lower()
+    try:
+        http_action = args.request.lower()
+    except AttributeError:
+        http_action = args.request[0].lower()
     header_dict = {h[0].split(':')[0]:h[0].split(':')[1]
                    for h in args.header}
 


### PR DESCRIPTION
Assigning the http_action kept erroring for me, because args.request ended up being ['POST'] instead of just 'POST', so I added a try/except around it to account for it being a single-member list.
