### PR TITLE
fix broken parsing when headers contain multiple colons.

### DIFF
--- a/curl_to_requests/curl_to_requests.py
+++ b/curl_to_requests/curl_to_requests.py
@@ -134,7 +134,7 @@ def curl_to_requests(curl_str):
         http_action = args.request.lower()
     except AttributeError:
         http_action = args.request[0].lower()
-    header_dict = {h[0].split(':')[0]:h[0].split(':')[1]
+    header_dict = {h[0].split(':')[0]:  "".join(h[0].split(':')[1:])
                    for h in args.header}
 
     params_dict = {}#''.join(args.data_urlencode) #BROKEN


### PR DESCRIPTION
I noticed that the parsing of headers broke when there was something like this:

-H "headername:contentcontent:contentcontentcontent"

I don't know if this is even legal, but browsers do accept it, so you can find this in the wild.
