### PR TITLE
Fix the AttributeError: 'function' object has no attribute 'curl_to_r…

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,5 +13,5 @@ curl_cmd = '''curl 'https://github.com/mosesschwartz/curl_to_requests' \\
     -H 'Referer: https://github.com/mosesschwartz/curl_to_requests' \\
     -H 'Connection: keep-alive' --compressed'''
 
-print curl_to_requests.curl_to_requests(curl_cmd)
+print curl_to_requests(curl_cmd)
 ```


### PR DESCRIPTION
```print curl_to_requests.curl_to_requests(curl_cmd)``` generate an error:

```
1 print curl_to_requests.curl_to_requests(curl_cmd)
AttributeError: 'function' object has no attribute 'curl_to_requests'
```
because you have import `curl_to_requests` from `curl_to_requests` already so using the:

```print curl_to_requests(curl_cmd)```
is sufficient